### PR TITLE
OP permission checker

### DIFF
--- a/src/main/java/me/txmc/core/Main.java
+++ b/src/main/java/me/txmc/core/Main.java
@@ -3,6 +3,7 @@ package me.txmc.core;
 import lombok.Getter;
 import me.txmc.core.antiillegal.AntiIllegalMain;
 import me.txmc.core.chat.ChatSection;
+import me.txmc.core.chat.listeners.OpWhiteListListener;
 import me.txmc.core.chat.tasks.AnnouncementTask;
 import me.txmc.core.command.CommandSection;
 import me.txmc.core.deathmessages.DeathMessageListener;
@@ -57,6 +58,7 @@ public class Main extends JavaPlugin {
         register(new CommandSection(this));
         register(new PatchSection(this));
         register(new DeathMessageListener());
+        register(new OpWhiteListListener(this));
         if (getServer().getPluginManager().getPlugin("VotifierPlus") != null) register(new VoteSection(this));
 
         for (Section section : sections) {

--- a/src/main/java/me/txmc/core/Main.java
+++ b/src/main/java/me/txmc/core/Main.java
@@ -29,6 +29,7 @@ import static me.txmc.core.util.GlobalUtils.log;
 
 public class Main extends JavaPlugin {
     @Getter private static Main instance;
+    @Getter public static String prefix;
     @Getter private ScheduledExecutorService executorService;
     private List<Section> sections;
     private List<Reloadable> reloadables;
@@ -43,6 +44,7 @@ public class Main extends JavaPlugin {
         instance = this;
         executorService = Executors.newScheduledThreadPool(4);
         startTime = System.currentTimeMillis();
+        prefix = getConfig().getString("PluginMessagePrefix", "&6[&18b&98t&cCore&6]");
         saveDefaultConfig();
         getLogger().addHandler(new LoggerHandler());
         Localization.loadLocalizations(getDataFolder());

--- a/src/main/java/me/txmc/core/chat/listeners/OpWhiteListListener.java
+++ b/src/main/java/me/txmc/core/chat/listeners/OpWhiteListListener.java
@@ -1,0 +1,99 @@
+package me.txmc.core.chat.listeners;
+
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCreativeEvent;
+import org.bukkit.event.player.*;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import static me.txmc.core.util.GlobalUtils.log;
+import static me.txmc.core.util.GlobalUtils.sendPrefixedLocalizedMessage;
+
+/**
+ * Listener to manage operator permissions on the server.
+ * Only players listed in the whitelist are allowed to have operator status.
+ *
+ * <p>This listener handles various events to ensure that unauthorized
+ * operators have their permissions revoked and receive notification.</p>
+ *
+ * <p>Events handled include:</p>
+ * <ul>
+ *     <li>Player join events</li>
+ *     <li>Command execution events</li>
+ *     <li>Player interaction events</li>
+ *     <li>Player world change events</li>
+ *     <li>Inventory creative mode events</li>
+ *     <li>Player game mode change events</li>
+ * </ul>
+ *
+ * @author Minelord9000 (agarciacorte)
+ * @since 2024/07/17 11:11 AM
+ */
+
+public class OpWhiteListListener implements Listener {
+    private final JavaPlugin plugin;
+
+    public OpWhiteListListener(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        checkOps(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onCommandEvent(PlayerCommandPreprocessEvent event) {
+        if(checkOps(event.getPlayer())){
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInteractionEvent(PlayerInteractEvent event) {
+        if(checkOps(event.getPlayer())){
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        checkOps(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onInventoryCreative(InventoryCreativeEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        if(checkOps(player)){
+            event.setCancelled(true);
+            player.setGameMode(GameMode.SURVIVAL);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {
+        Player player = event.getPlayer();
+        if(checkOps(player)){
+            if(event.getNewGameMode() == GameMode.CREATIVE){
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    public boolean checkOps(Player player) {
+        List<String> opUsersWhiteList = plugin.getConfig().getStringList("OpUsersWhiteList");
+
+        if ((player.isOp() || player.getGameMode() == GameMode.CREATIVE || player.hasPermission("*")) && !opUsersWhiteList.contains(player.getName())) {
+            player.setOp(false);
+            sendPrefixedLocalizedMessage(player, "op_not_allowed");
+            log(Level.SEVERE, "The player %s has had operator permissions revoked because it is not allowed.", player.getName());
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/txmc/core/util/GlobalUtils.java
+++ b/src/main/java/me/txmc/core/util/GlobalUtils.java
@@ -33,7 +33,7 @@ import java.util.Random;
  * This file was created as a part of 8b8tCore
  */
 public class GlobalUtils {
-    @Getter private static final String PREFIX = "&6[&18b&98t&cCore&6]";
+    @Getter private static final String PREFIX = Main.prefix;
 
     public static void info(String format) {
         log(Level.INFO, format);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -140,3 +140,4 @@ OpUsersWhiteList:
   - 'Leee'
   - 'SrGokuto'
   - 'TheTroll2001'
+PluginMessagePrefix: '&6[&18b&98t&cCore&6]'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -136,3 +136,7 @@ Patch:
 Commands:
   # to send to the player for /discord
   Discord: '&3Join us on discord at&r&a https://discord.8b8t.me'
+OpUsersWhiteList:
+  - 'Leee'
+  - 'SrGokuto'
+  - 'TheTroll2001'

--- a/src/main/resources/localization/ar.yml
+++ b/src/main/resources/localization/ar.yml
@@ -70,6 +70,7 @@ tpa_request_denied_from: "&a%s&r&c has denied your request"
 tpa_request_denied_to: "&3Request denied successfully"
 tpa_pending_request: "&a%s&r &chas a pending request"
 tpa_to_left: "&cTPA cancelled because&r&a %s&r&c left"
+op_not_allowed: "&cYou are not allowed to be op"
 announcements:
   - '&6[&18b&98t&6]&6 Visit &chttps://votefor.8b8t.me &6and vote to receive free /nc and 5 extra homes'
   - '&6[&18b&98t&6]&6 Donate to help support 8b8t at &chttps://donate.8b8t.me'

--- a/src/main/resources/localization/cn.yml
+++ b/src/main/resources/localization/cn.yml
@@ -70,6 +70,7 @@ tpa_request_denied_from: "&a%s&r&c拒绝了你的请求"
 tpa_request_denied_to: "&3请求已成功拒绝"
 tpa_pending_request: "&a%s&r &c有一个待处理的请求"
 tpa_to_left: "&cTPA已取消，因为&r&a %s&r&c离开了"
+op_not_allowed: "&c您无权成为操作员"
 announcements:
   - '&6[&18b&98t&6]&6 访问 &chttps://votefor.8b8t.me &6并投票即可获得免费 /nc 和 5 个额外住宅'
   - '&6[&18b&98t&6]&6 捐款以帮助支持 8b8t，网址为 &chttps://donate.8b8t.me'

--- a/src/main/resources/localization/en.yml
+++ b/src/main/resources/localization/en.yml
@@ -70,6 +70,7 @@ tpa_request_denied_from: "&a%s&r&c has denied your request"
 tpa_request_denied_to: "&3Request denied successfully"
 tpa_pending_request: "&a%s&r &chas a pending request"
 tpa_to_left: "&cTPA cancelled because&r&a %s&r&c left"
+op_not_allowed: "&cYou are not allowed to be op"
 #Complex messages
 HelpMessage:
   - '&1--------------------------------------'

--- a/src/main/resources/localization/es.yml
+++ b/src/main/resources/localization/es.yml
@@ -69,6 +69,7 @@ tpa_request_denied_from: "&a%s&r&c ha denegado tu solicitud"
 tpa_request_denied_to: "&3Solicitud denegada con éxito"
 tpa_pending_request: "&a%s&r &ctiene una solicitud pendiente"
 tpa_to_left: "&cTPA cancelado porque&r&a %s&r&c se ha desconectado"
+op_not_allowed: "&cNo tienes permiso para ser operador"
 announcements:
   - '&6[&18b&98t&6]&6 Visite &chttps://votefor.8b8t.me &6y vote para recibir /nc gratis y 5 casas adicionales'
   - '&6[&18b&98t&6]&6 Done para ayudar a apoyar 8b8t en &chttps://donate.8b8t.me'

--- a/src/main/resources/localization/it.yml
+++ b/src/main/resources/localization/it.yml
@@ -70,6 +70,7 @@ tpa_request_denied_from: "&a%s&r&c ha rifiutato la tua richiesta"
 tpa_request_denied_to: "&3Richiesta rifiutata correttamente"
 tpa_pending_request: "&a%s&r &cha una richiesta in sospeso"
 tpa_to_left: "&cTPA cancellato perchè&r&a %s&r&c ha leftato"
+op_not_allowed: "&cNon hai il permesso di essere operatore"
 announcements:
   - '&6[&18b&98t&6]&6 Visita &chttps://votefor.8b8t.me &6e vota per ricevere /nc gratuito e 5 case extra'
   - '&6[&18b&98t&6]&6 Fai una donazione per aiutare a sostenere 8b8t su &chttps://donate.8b8t.me'

--- a/src/main/resources/localization/pt.yml
+++ b/src/main/resources/localization/pt.yml
@@ -70,6 +70,7 @@ tpa_request_denied_from: "&a%s&r&c negou o seu pedido"
 tpa_request_denied_to: "&3Pedido negado com sucesso"
 tpa_pending_request: "&a%s&r &ctem um pedido pendente"
 tpa_to_left: "&cPedido de TPA cancelado porque&r&a %s&r&c saiu"
+op_not_allowed: "&cVocê não tem permissão para ser operador"
 announcements:
   - '&6[&18b&98t&6]&6 Visite &chttps://votefor.8b8t.me &6e vote para receber /nc grátis e 5 casas extras'
   - '&6[&18b&98t&6]&6 Doe para ajudar a apoiar 8b8t em &chttps://donate.8b8t.me'

--- a/src/main/resources/localization/ru.yml
+++ b/src/main/resources/localization/ru.yml
@@ -69,6 +69,7 @@ tpa_request_denied_from: "&a%s&r&c отклонил ваш запрос"
 tpa_request_denied_to: "&3Запрос успешно отклонен"
 tpa_pending_request: "&a%s&r &cимеет ожидающий запрос"
 tpa_to_left: "&c/tpa отменен, так как&r&a %s&r&c покинул игру"
+op_not_allowed: "&cУ вас нет разрешения на оператора"
 announcements:
   - '&6[&18b&98t&6]&6 Посетите &chttps://votefor.8b8t.me &6и проголосуйте, чтобы получить бесплатный /nc и 5 дополнительных домов.'
   - '&6[&18b&98t&6]&6 Сделайте пожертвование в поддержку 8b8t на сайте &chttps://donate.8b8t.me'


### PR DESCRIPTION
### Description
Implemented an `OpWhiteListListener` to verify operator permissions on the server. This listener ensures that only users listed in the whitelist can have operator status. Unauthorized operators have their permissions revoked automatically.

### Changes Made
- Added `OpWhiteListListener` class to handle various player events related to operator permissions.
- Implemented checks for joining, command execution, player interaction, world change, creative mode inventory access, and game mode change events.
- Revoked operator status and notified players not listed in the whitelist when attempting to gain or maintain operator permissions.
- New operators must be added to the `OpUsersWhiteList` in `config.yml`.
- Added `PluginMessagePrefix` (prefix option) to the `config.yml`

### Checklist
- [x] Tested the functionality locally on a server environment.
- [x] Verified all events are handled appropriately.
- [x] If the user is not whitelisted and has operator permissions, the event will be cancelled.