### PR TITLE
Custom View and Simulation Distance Feature with permissions

### DIFF
--- a/src/main/java/me/txmc/core/Main.java
+++ b/src/main/java/me/txmc/core/Main.java
@@ -6,6 +6,8 @@ import me.txmc.core.chat.ChatSection;
 import me.txmc.core.chat.listeners.OpWhiteListListener;
 import me.txmc.core.chat.tasks.AnnouncementTask;
 import me.txmc.core.command.CommandSection;
+import me.txmc.core.customexperience.PlayerSimulationDistance;
+import me.txmc.core.customexperience.PlayerViewDistance;
 import me.txmc.core.deathmessages.DeathMessageListener;
 import me.txmc.core.home.HomeManager;
 import me.txmc.core.patch.PatchSection;
@@ -60,6 +62,8 @@ public class Main extends JavaPlugin {
         register(new CommandSection(this));
         register(new PatchSection(this));
         register(new DeathMessageListener());
+        register(new PlayerViewDistance(this));
+        register(new PlayerSimulationDistance(this));
         register(new OpWhiteListListener(this));
         if (getServer().getPluginManager().getPlugin("VotifierPlus") != null) register(new VoteSection(this));
 

--- a/src/main/java/me/txmc/core/customexperience/PlayerSimulationDistance.java
+++ b/src/main/java/me/txmc/core/customexperience/PlayerSimulationDistance.java
@@ -1,0 +1,69 @@
+package me.txmc.core.customexperience;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.logging.Level;
+import static me.txmc.core.util.GlobalUtils.log;
+
+/**
+ * This class is part of the custom experience module for the 8b8tCore plugin.
+ * It listens for player join events and sets the simulation distance based on permissions.
+ *
+ * <p>Designed to customize the simulation distance for players according to their permissions.
+ * Each player can have a unique simulation distance set when they join the server.</p>
+ *
+ * <p>Functionality includes:</p>
+ * <ul>
+ *     <li>Listening for player join events</li>
+ *     <li>Checking player permissions to determine simulation distance</li>
+ *     <li>Setting the simulation distance for each player</li>
+ * </ul>
+ *
+ * <p>The simulation distance is determined by the highest valid permission found,
+ * within a range of 2 to 32 chunks. If no specific permission is found, a default value is used.</p>
+ *
+ * @author Minelord9000 (agarciacorte)
+ * @since 2024/07/18 12:42 PM
+ */
+public class PlayerSimulationDistance implements Listener {
+    private final JavaPlugin plugin;
+
+    public PlayerSimulationDistance(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        setSimulationDistance(player);
+    }
+
+    private void setSimulationDistance(Player player) {
+        int simulationDistance = plugin.getConfig().getInt("simulationdistance.default", 4);
+        int maxChunks = 2;
+
+        for (String permission : player.getEffectivePermissions().stream().map(PermissionAttachmentInfo::getPermission).toList()) {
+            if (permission.startsWith("8b8tcore.simulationdistance.")) {
+                String chunksStr = permission.replace("8b8tcore.simulationdistance.", "");
+                try {
+                    int chunks = Integer.parseInt(chunksStr);
+                    chunks = Math.max(2, Math.min(32, chunks));
+
+                    if (chunks > maxChunks) {
+                        maxChunks = chunks;
+                    }
+                    simulationDistance = maxChunks;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        player.setSimulationDistance(simulationDistance);
+        log(Level.INFO,"Simulation distance set to " + simulationDistance + " chunks for player: " + player.getName());
+    }
+}

--- a/src/main/java/me/txmc/core/customexperience/PlayerViewDistance.java
+++ b/src/main/java/me/txmc/core/customexperience/PlayerViewDistance.java
@@ -1,0 +1,70 @@
+package me.txmc.core.customexperience;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.logging.Level;
+import static me.txmc.core.util.GlobalUtils.log;
+
+/**
+ * This class is part of the custom experience module for the 8b8tCore plugin.
+ * It listens for player join events and sets the view distance based on permissions.
+ *
+ * <p>Designed to customize the view distance for players according to their permissions.
+ * Each player can have a unique view distance set when they join the server.</p>
+ *
+ * <p>Functionality includes:</p>
+ * <ul>
+ *     <li>Listening for player join events</li>
+ *     <li>Checking player permissions to determine view distance</li>
+ *     <li>Setting the view distance for each player</li>
+ * </ul>
+ *
+ * <p>The view distance is determined by the highest valid permission found,
+ * within a range of 2 to 32 chunks. If no specific permission is found, a default value is used.</p>
+ *
+ * @author Minelord9000 (agarciacorte)
+ * @since 2024/07/18 12:42 PM
+ */
+public class PlayerViewDistance implements Listener {
+    private final JavaPlugin plugin;
+
+    public PlayerViewDistance(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        setRenderDistance(player);
+    }
+
+    private void setRenderDistance(Player player) {
+        int renderDistance = plugin.getConfig().getInt("viewdistance.default", 2);
+        int maxChunks = 2;
+
+        for (String permission : player.getEffectivePermissions().stream().map(PermissionAttachmentInfo::getPermission).toList()) {
+            if (permission.startsWith("8b8tcore.viewdistance.")) {
+                String chunksStr = permission.replace("8b8tcore.viewdistance.", "");
+                try {
+                    int chunks = Integer.parseInt(chunksStr);
+                    chunks = Math.max(2, Math.min(32, chunks));
+
+                    if (chunks > maxChunks) {
+                        maxChunks = chunks;
+                    }
+                    renderDistance = maxChunks;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        player.setSendViewDistance(renderDistance);
+        player.setViewDistance(renderDistance);
+        log(Level.INFO,"View distance set to " + renderDistance + " chunks for player: " + player.getName());
+    }
+}

--- a/src/main/java/me/txmc/core/deathmessages/DeathMessageListener.java
+++ b/src/main/java/me/txmc/core/deathmessages/DeathMessageListener.java
@@ -42,9 +42,6 @@ public class DeathMessageListener implements Listener {
         Entity killer = victim.getKiller();
         ItemStack weapon = null;
 
-        if (victim.getLastDamageCause() == null) {
-            return;
-        }
 
         if (victim.getLastDamageCause() == null) {
             return;

--- a/src/main/java/me/txmc/core/deathmessages/DeathMessageListener.java
+++ b/src/main/java/me/txmc/core/deathmessages/DeathMessageListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import static me.txmc.core.util.GlobalUtils.sendDeathMessage;
@@ -42,6 +43,14 @@ public class DeathMessageListener implements Listener {
         ItemStack weapon = null;
 
         if (victim.getLastDamageCause() == null) {
+            return;
+        }
+
+        if (victim.getLastDamageCause() == null) {
+            return;
+        }
+
+        if (hasTotems(victim)) {
             return;
         }
 
@@ -86,6 +95,10 @@ public class DeathMessageListener implements Listener {
         }
 
         Player victim = (Player) event.getEntity();
+
+        if (hasTotems(victim)) {
+            return;
+        }
 
         if (victim.getHealth() - event.getFinalDamage() > 0) {
             return;
@@ -144,6 +157,19 @@ public class DeathMessageListener implements Listener {
 
     private static ItemStack getKillWeapon(Player killer) {
         return killer.getInventory().getItemInMainHand();
+    }
+
+    private boolean hasTotems(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        boolean hasTotems = false;
+
+        if(inventory.getItemInMainHand().getType() == Material.TOTEM_OF_UNDYING){
+            hasTotems = true;
+        } else if(inventory.getItemInOffHand().getType() == Material.TOTEM_OF_UNDYING){
+            hasTotems = true;
+        }
+
+        return hasTotems;
     }
 
     private String getWeaponName(ItemStack weapon) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -141,3 +141,7 @@ OpUsersWhiteList:
   - 'SrGokuto'
   - 'TheTroll2001'
 PluginMessagePrefix: '&6[&18b&98t&cCore&6]'
+viewdistance:
+  default: 6
+simulationdistance:
+  default: 4

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -35,3 +35,40 @@ commands:
   world:
   vote:
   tps:
+permissions:
+  8b8tcore.viewdistance.default:
+    description: Permission for the default view distance
+    default: true
+  8b8tcore.viewdistance.4:
+    description: Permission to set a view distance of 4 chunks
+    default: false
+  8b8tcore.viewdistance.6:
+    description: Permission to set a view distance of 6 chunks
+    default: false
+  8b8tcore.viewdistance.8:
+    description: Permission to set a view distance of 8 chunks
+    default: false
+  8b8tcore.viewdistance.16:
+    description: Permission to set a view distance of 16 chunks
+    default: false
+  8b8tcore.viewdistance.32:
+    description: Permission to set a view distance of 32 chunks
+    default: false
+  8b8tcore.simulationdistance.default:
+    description: Permission for the default simulation distance
+    default: true
+  8b8tcore.simulationdistance.4:
+    description: Permission to set a simulation distance of 4 chunks
+    default: false
+  8b8tcore.simulationdistance.6:
+    description: Permission to set a simulation distance of 6 chunks
+    default: false
+  8b8tcore.simulationdistance.8:
+    description: Permission to set a simulation distance of 8 chunks
+    default: false
+  8b8tcore.simulationdistance.16:
+    description: Permission to set a simulation distance of 16 chunks
+    default: false
+  8b8tcore.simulationdistance.32:
+    description: Permission to set a simulation distance of 32 chunks
+    default: false


### PR DESCRIPTION
# Custom View and Simulation Distance Feature

## Summary

New feature that allows for custom view and simulation distances based on player permissions. It adds two new listeners, `PlayerViewDistance` and `PlayerSimulationDistance`, which set the respective distances when a player joins the server.

## Features

### PlayerViewDistance

- **Description**: Customizes the view distance for players according to their permissions.
- **Functionality**:
  - Listens for player join events.
  - Checks player permissions to determine view distance.
  - Sets the view distance for each player.

### PlayerSimulationDistance

- **Description**: Customizes the simulation distance for players according to their permissions.
- **Functionality**:
  - Listens for player join events.
  - Checks player permissions to determine simulation distance.
  - Sets the simulation distance for each player.
  
To assign the view distance or simulation distance permissions, the number of chunks is taken as an argument. There are predefined options: `default`, `4`, `6`, `8`, `16`, and `32`. However, any number of chunks between 2 and 32 can be specified. If the user has multiple permissions, the one with the highest number of chunks will be used.

Here is the [demonstration video](https://youtu.be/qZ5pLejJDeY) on how to use the new implementation.