### PR TITLE
Change of method so that it can be used in other classes

### DIFF
--- a/src/main/java/me/txmc/core/dupe/zombiedupe/ZombieDupe.java
+++ b/src/main/java/me/txmc/core/dupe/zombiedupe/ZombieDupe.java
@@ -3,7 +3,6 @@ package me.txmc.core.dupe.zombiedupe;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Zombie;
 import org.bukkit.event.EventHandler;
@@ -12,13 +11,12 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
-import static me.txmc.core.util.GlobalUtils.sendPrefixedLocalizedMessage;
+import static me.txmc.core.util.GlobalUtils.*;
 
 /**
  * Handles the duplication of items held by zombies when shot with an arrow by an elytra-flying player.
@@ -52,14 +50,11 @@ public class ZombieDupe implements Listener {
     @EventHandler
     public void onEntityHitByArrow(EntityDamageByEntityEvent event) {
 
-        if (event.getDamager() instanceof Arrow) {
-            Arrow arrow = (Arrow) event.getDamager();
+        if (event.getDamager() instanceof Arrow arrow) {
 
-            if (event.getEntity() instanceof Zombie) {
-                Zombie zombie = (Zombie) event.getEntity();
+            if (event.getEntity() instanceof Zombie zombie) {
 
-                if (arrow.getShooter() instanceof Player) {
-                    Player player = (Player) arrow.getShooter();
+                if (arrow.getShooter() instanceof Player player) {
 
                     final boolean ENABLED = plugin.getConfig().getBoolean("ZombieDupe.enabled", true);
                     if (!ENABLED) return;
@@ -75,7 +70,7 @@ public class ZombieDupe implements Listener {
                         if (randomSuccess >= PROBABILITY_PERCENTAGE) return;
 
                         Block block = zombie.getLocation().getBlock();
-                        UUID chunkId = getChunkId(block);
+                        UUID chunkId = getChunkUUID(block);
                         final long DUPLICATION_INTERVAL = plugin.getConfig().getLong("ZombieDupe.dupeCooldown", 200L);
 
                         if (System.currentTimeMillis() - lastDuplicationTimes.getOrDefault(chunkId, 0L) < DUPLICATION_INTERVAL) {
@@ -106,19 +101,5 @@ public class ZombieDupe implements Listener {
                 }
             }
         }
-    }
-
-    private UUID getChunkId(Block block) {
-        int x = block.getChunk().getX();
-        int z = block.getChunk().getZ();
-
-        return UUID.nameUUIDFromBytes((x + ":" + z).getBytes());
-    }
-
-    private int getItemCountInChunk(Block block) {
-        return (int) Arrays.stream(block.getChunk().getEntities())
-                .filter(entity -> entity instanceof Item)
-                .map(entity -> (Item) entity)
-                .count();
     }
 }

--- a/src/main/java/me/txmc/core/util/GlobalUtils.java
+++ b/src/main/java/me/txmc/core/util/GlobalUtils.java
@@ -10,18 +10,25 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -167,5 +174,24 @@ public class GlobalUtils {
     }
     public static String formatLocation(Location location) {
         return location.getWorld().getName() + " " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ();
+    }
+    public static @NotNull UUID getChunkUUID(@NotNull Block block) {
+        int x = block.getChunk().getX();
+        int z = block.getChunk().getZ();
+
+        return UUID.nameUUIDFromBytes((x + ":" + z).getBytes());
+    }
+    public static @NotNull UUID getChunkUUID(@NotNull Chunk chunk) {
+        int x = chunk.getX();
+        int z = chunk.getZ();
+
+        return UUID.nameUUIDFromBytes((x + ":" + z).getBytes());
+    }
+
+    public static int getItemCountInChunk(Block block) {
+        return (int) Arrays.stream(block.getChunk().getEntities())
+                .filter(entity -> entity instanceof Item)
+                .map(entity -> (Item) entity)
+                .count();
     }
 }


### PR DESCRIPTION
I removed the two methods from the `ZombieDupe` class and moved them to `GlobalUtils`, because they seemed like very generic methods for a single class.

```java
    public static @NotNull UUID getChunkUUID(@NotNull Block block) {
        int x = block.getChunk().getX();
        int z = block.getChunk().getZ();

        return UUID.nameUUIDFromBytes((x + ":" + z).getBytes());
    }

    public static @NotNull UUID getChunkUUID(@NotNull Chunk chunk) {
        int x = chunk.getX();
        int z = chunk.getZ();

        return UUID.nameUUIDFromBytes((x + ":" + z).getBytes());
    }

    public static int getItemCountInChunk(Block block) {
        return (int) Arrays.stream(block.getChunk().getEntities())
                .filter(entity -> entity instanceof Item)
                .map(entity -> (Item) entity)
                .count();
    }
```