### PR TITLE
Prevent Prefilled Chests with arbitrary items inside from storage containers.

### DIFF
--- a/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
+++ b/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
@@ -10,6 +10,7 @@ import me.txmc.core.Main;
 import me.txmc.core.Section;
 import me.txmc.core.antiillegal.check.Check;
 import me.txmc.core.antiillegal.check.checks.*;
+import me.txmc.core.antiillegal.check.checks.antiprefilledchests;
 import me.txmc.core.antiillegal.listeners.IllegalBlocksCleaner;
 import me.txmc.core.antiillegal.listeners.PlayerListeners;
 import me.txmc.core.antiillegal.listeners.MiscListeners;
@@ -43,7 +44,8 @@ public class AntiIllegalMain implements Section {
             new LegacyTextCheck(),
             new StackedTotemCheck(),
             new ShulkerCeptionCheck(),
-            new IllegalItemCheck()
+            new IllegalItemCheck(),
+            new antiprefilledchests()
     ));
 
     private ConfigurationSection config;

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/antiprefilledchests.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/antiprefilledchests.java
@@ -1,0 +1,75 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Container;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+
+/**
+ * Prevents players from having items already prefilled in chests this is not possible without modifying the NBT data of the item.
+ * @author MindComplexity (Aka Libalpm)
+ * @since 2025-08-20
+ */
+public class antiprefilledchests implements Check {
+    
+    @Override
+    public boolean check(ItemStack item) {
+        if (item == null) return false;
+        if (!isNonShulkerContainer(item)) return false;
+
+        if (!(item.getItemMeta() instanceof BlockStateMeta meta)) return false;
+
+        BlockState state = meta.getBlockState();
+        if (!(state instanceof Container container)) return false;
+
+        Inventory inv = container.getInventory();
+        
+        for (ItemStack content : inv.getContents()) {
+            if (content != null) {
+                return true; 
+            }
+        }
+        
+        return false;
+    }
+
+    @Override
+    public boolean shouldCheck(ItemStack item) {
+        return isNonShulkerContainer(item);
+    }
+
+    @Override
+    public void fix(ItemStack item) {
+        if (item == null) return;
+        if (!isNonShulkerContainer(item)) return;
+
+        if (!(item.getItemMeta() instanceof BlockStateMeta meta)) return;
+
+        BlockState state = meta.getBlockState();
+        if (!(state instanceof Container container)) return;
+
+        Inventory inv = container.getInventory();
+        
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, null);
+        }
+        
+        container.update();
+        meta.setBlockState(container);
+        item.setItemMeta(meta);
+    }
+    
+    private boolean isNonShulkerContainer(ItemStack item) {
+        if (item == null) return false;
+        String type = item.getType().toString();
+        return type.endsWith("CHEST") ||
+               type.endsWith("TRAPPED_CHEST") ||
+               type.endsWith("BARREL") ||
+               type.endsWith("DISPENSER") ||
+               type.endsWith("DROPPER") ||
+               type.endsWith("HOPPER");
+    }
+}


### PR DESCRIPTION
- Fixes Infinite Item storage by nesting items inside a chest, example being spawned with a command such as: 
```/give @p chest[container=[{slot:0,item:{id:obsidian,count:64}},{slot:1,item:{id:obsidian,count:64}}]] 1```