### PR TITLE
8b8tcore 1.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.txmc</groupId>
     <artifactId>8b8tCore</artifactId>
-    <version>1.5.11</version>
+    <version>1.5.12</version>
     <packaging>jar</packaging>
 
     <name>8b8tCore</name>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>dev.folia</groupId>
             <artifactId>folia-api</artifactId>
-            <version>1.20.2-R0.1-SNAPSHOT</version>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
+++ b/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
@@ -10,17 +10,11 @@ import me.txmc.core.Main;
 import me.txmc.core.Section;
 import me.txmc.core.antiillegal.check.Check;
 import me.txmc.core.antiillegal.check.checks.*;
-import me.txmc.core.antiillegal.check.checks.antiprefilledchests;
-import me.txmc.core.antiillegal.listeners.IllegalBlocksCleaner;
-import me.txmc.core.antiillegal.listeners.PlayerListeners;
-import me.txmc.core.antiillegal.listeners.MiscListeners;
-import me.txmc.core.antiillegal.listeners.InventoryListeners;
-import me.txmc.core.antiillegal.listeners.AttackListener;
-import me.txmc.core.antiillegal.listeners.StackedTotemsListener;
-import org.bukkit.configuration.ConfigurationSection;
+import me.txmc.core.antiillegal.listeners.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.Material;
 import org.bukkit.event.Cancellable;
+import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +54,8 @@ public class AntiIllegalMain implements Section {
                 new MiscListeners(this),
                 new InventoryListeners(this),
                 new AttackListener(),
-                new StackedTotemsListener()
+                new StackedTotemsListener(),
+                new PlayerEffectListener(plugin)
         );
 
         if (config.getBoolean("EnableIllegalBlocksCleaner", true)) {

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/PlayerEffectCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/PlayerEffectCheck.java
@@ -1,0 +1,176 @@
+package me.txmc.core.antiillegal.check.checks;
+
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Checks player effects on players to ensure they don't have illegal values
+ * @author MindComplexity (aka Libalpm)
+ * @since 2025-08-21
+ */
+public class PlayerEffectCheck implements Check {
+
+    // Vanilla potion effect limits: Map<EffectType, MaxLevel>
+    private static final Map<PotionEffectType, Integer> VANILLA_LEVEL_LIMITS = new HashMap<>();
+    
+    private static final int MAX_LEGAL_DURATION = 9600; // 8 minutes for vanilla potions
+    private static final int MAX_LEGAL_DURATION_EXTENDED = 19200; // 16 minutes (extended potions)
+    private static final int MAX_LEGAL_DURATION_SPECIAL = 24000; // 20 minutes (edgecases like Bad Omen)
+    
+    static {
+        // Standard potions (max level 1)
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.NIGHT_VISION, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.INVISIBILITY, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.LUCK, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.SLOW_FALLING, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.WATER_BREATHING, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.FIRE_RESISTANCE, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.WEAKNESS, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.DOLPHINS_GRACE, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.CONDUIT_POWER, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.ABSORPTION, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.DARKNESS, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.OOZING, 1);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.GLOWING, 1);
+
+        /*
+        // Bedrock (Not in the Bukkit API as it's only for Java)
+        // https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html
+        // VANILLA_LEVEL_LIMITS.put(PotionEffectType.Fatal_Poison, 1);
+        // Removed in 1.21
+        // VANILLA_LEVEL_LIMITS.put(PotionEffectType.RAID_OMEN, 0); // Pillager RAIDS
+        // Illegal effects
+        // VANILLA_LEVEL_LIMITS.put(PotionEffectType.HEALTH_BOOST, 0);
+        */
+       
+        // Potions with max level 2
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.SPEED, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.STRENGTH, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.REGENERATION, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.POISON, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.JUMP_BOOST, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.HASTE, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.INSTANT_DAMAGE, 2);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.INSTANT_HEALTH, 2);
+
+        // Potions with max level 4
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.SLOWNESS, 4);
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.RESISTANCE, 4);
+
+        
+        // Special cases
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.WIND_CHARGED, 0); // Windcharge weapon
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.INFESTED, 0); // Windcharge weapon
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.TRIAL_OMEN, 0); // Trial Chamber
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.WEAVING, 0); // Creates cobwebs on death
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.WITHER, 2); // Wither Boss - Potion of Decay
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.SATURATION, 0); // Only via Golden Apples
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.UNLUCK, 0); // Only via commands
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.LEVITATION, 2); // Shulkers 
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.MINING_FATIGUE, 3); // Elder Guardian
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.HUNGER, 3); // Pufferfish
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.HERO_OF_THE_VILLAGE, 5); // Village curing
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.BAD_OMEN, 5); // Pillager raids
+
+
+    }
+
+    @Override
+    public boolean check(ItemStack item) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldCheck(ItemStack item) {
+        return false;
+    }
+
+    @Override
+    public void fix(ItemStack item) {
+        // This function does nothing.
+    }
+
+    /**
+     * Check if a player has any illegal potion effects
+     * @param player The player to check
+     * @return true if player has illegal effects, false otherwise
+     */
+    public boolean checkPlayerEffects(Player player) {
+        if (player == null) return false;
+        
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            if (isIllegalEffect(effect)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Remove all illegal potion effects from a player
+     * @param player The player to fix
+     */
+    public void fixPlayerEffects(Player player) {
+        if (player == null) return;
+        
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            if (isIllegalEffect(effect)) {
+                player.removePotionEffect(effect.getType());
+            }
+        }
+    }
+
+    /**
+     * Check if a specific effect is illegal
+     * @param effect The potion effect to check
+     * @return true if the effect is illegal, false otherwise
+     */
+    public boolean isIllegalEffect(PotionEffect effect) {
+        if (effect == null) return false;
+        
+        PotionEffectType type = effect.getType();
+         // Amplifier starts at 0, so +1 for the actual level
+        int level = effect.getAmplifier() + 1;
+        int duration = effect.getDuration();
+        
+        // If the effect type is not in the map, it is illegal or unknown
+        // You can add more effects to the map if you want to allow them. 
+        if (!VANILLA_LEVEL_LIMITS.containsKey(type)) {
+            return true;
+        }
+        
+        int maxAllowedLevel = VANILLA_LEVEL_LIMITS.get(type);
+        
+        if (maxAllowedLevel == 0) {
+            return true;
+        }
+        
+        if (level > maxAllowedLevel) {
+            return true;
+        }
+        
+        if (isExcessiveDuration(duration, type)) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    private boolean isExcessiveDuration(int duration, PotionEffectType type) {
+        if (type == PotionEffectType.BAD_OMEN) {
+            return duration > MAX_LEGAL_DURATION_SPECIAL;
+        }
+        
+        if (duration > MAX_LEGAL_DURATION_EXTENDED) {
+            return true;
+        }
+        return duration > MAX_LEGAL_DURATION;
+    }
+}

--- a/src/main/java/me/txmc/core/antiillegal/listeners/PlayerEffectListener.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/PlayerEffectListener.java
@@ -1,0 +1,102 @@
+package me.txmc.core.antiillegal.listeners;
+
+import me.txmc.core.antiillegal.check.checks.PlayerEffectCheck;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Listener to monitor and fix illegal potion effects on players
+ * Some of this code was inspired by surf's antiillegal plugin
+ * https://github.com/Winds-Studio/Surf/blob/main/src/main/java/cn/dreeam/surf/modules/antiillegal/IllegalDamageAndPotionCheck.java you can find the original code there.
+ * 
+ * This listener uses a single repeating task to periodically check players,
+ * lu: avoiding multiple timers being scheduled for the same purpose.
+ * 
+ * @author Libalpm (MindComplexity)
+ * @since 2025-08-20
+ */
+public class PlayerEffectListener implements Listener {
+    
+    private final Plugin plugin;
+    private final PlayerEffectCheck effectCheck;
+    private final int checkInterval;
+    
+    public PlayerEffectListener(Plugin plugin) {
+        /***
+         *  MODIFY THIS TO CHANGE THE CHECK INTERVAL
+         *  This is the interval at which the plugin will check for illegal effects.
+         *  The default is 100 ticks, which is 5 seconds. (20 ticks = 1 second)
+         */
+        this(plugin, 100); 
+    }
+    
+    public PlayerEffectListener(Plugin plugin, int checkInterval) {
+        this.plugin = plugin;
+        this.effectCheck = new PlayerEffectCheck();
+        this.checkInterval = checkInterval;        
+        startEffectChecker();
+    }
+    
+    /**
+     * Start the periodic task to check all online players.
+     * This is the only repeating timer used in this listener.
+     */
+    private void startEffectChecker() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                checkAllPlayers();
+            }
+        }.runTaskTimer(plugin, 20L, checkInterval);
+    }
+    
+    /**
+     * Check all online players for illegal effects
+     */
+    private void checkAllPlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            checkPlayer(player);
+        }
+    }
+    
+    /**
+     * Check and fix a specific player's effects
+     */
+    private void checkAndFixPlayerEffects(Player player) {
+        if (effectCheck.checkPlayerEffects(player)) {
+            effectCheck.fixPlayerEffects(player);
+        }
+    }
+    
+    /**
+     * Check player effects when they join the server.
+     * 
+     * Currently, this just checks the player immediately on join.
+     * If you have some custom plugin that applies after join just modify this with a tick timer. 
+     */
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        checkPlayer(event.getPlayer());
+    }
+    
+    /**
+     * API Call for a specific player (can be called from commands or other parts of the code)
+     */
+    public void checkPlayer(Player player) {
+        if (player != null && player.isValid() && !player.isDead()) {
+            checkAndFixPlayerEffects(player);
+        }
+    }
+    
+    /**
+     * Get the effect check instance for external use
+     */
+    public PlayerEffectCheck getEffectCheck() {
+        return effectCheck;
+    }
+}

--- a/src/main/java/me/txmc/core/dupe/zombiedupe/ZombieDupe.java
+++ b/src/main/java/me/txmc/core/dupe/zombiedupe/ZombieDupe.java
@@ -62,7 +62,7 @@ public class ZombieDupe implements Listener {
 
                 if (arrow.getShooter() instanceof Player) {
                     Player player = (Player) arrow.getShooter();
-                    PotionEffect jumpBoost = player.getPotionEffect(PotionEffectType.JUMP);
+                    PotionEffect jumpBoost = player.getPotionEffect(PotionEffectType.JUMP_BOOST);
 
                     final boolean ENABLED = plugin.getConfig().getBoolean("ZombieDupe.enabled", true);
                     if (!ENABLED) return;

--- a/src/main/java/me/txmc/core/patch/listeners/EntitySwitchWorldListener.java
+++ b/src/main/java/me/txmc/core/patch/listeners/EntitySwitchWorldListener.java
@@ -25,8 +25,9 @@ public class EntitySwitchWorldListener implements Listener {
     private final Main main;
 
     private final HashSet<EntityType> blacklist = new HashSet<>() {{
-        add(EntityType.BOAT);
-        add(EntityType.DROPPED_ITEM);
+        // Updated 8/21/25 to support all boat types for 1.21.6 Folia API the previous symbol has been removed. 
+        addAll(Arrays.stream(EntityType.values()).filter(e -> e.name().contains("BOAT")).toList());
+        add(EntityType.ITEM);
         addAll(Arrays.stream(EntityType.values()).filter(e -> e.name().contains("MINECART")).toList());
     }};
     @EventHandler

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: 8b8tCore
 main: me.txmc.core.Main
-version: 1.5.11
+version: 1.5.12
 author: 254n_m, agarciacort, Leeewith3Es
 description: A core plugin for 8b8t
-api-version: 1.20
+api-version: 1.21
 folia-supported: true
 softdepend:
   - VotifierPlus


### PR DESCRIPTION
- Simplified imports for anti illegal to use a recursive lookup due to there being a lot of listeners / checks.
- Removed prefilled chests import as it's already included in the recursive lookup.
- Now Checks Player Effects and dispels them if it's an illegal duration / illegal amplifier amount. 
- Updated to folia-api 1.21.6-R0.1-SNAPSHOT API (Latest Version)
- Fixed bugs with the version port. 