### PR TITLE
Update 8b8tCore to 1.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.txmc</groupId>
     <artifactId>8b8tCore</artifactId>
-    <version>1.6.2</version>
+    <version>1.6.3</version>
     <packaging>jar</packaging>
 
     <name>8b8tCore</name>

--- a/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
+++ b/src/main/java/me/txmc/core/antiillegal/AntiIllegalMain.java
@@ -40,6 +40,7 @@ public class AntiIllegalMain implements Section {
             new StackedTotemCheck(),
             new ShulkerCeptionCheck(),
             new IllegalItemCheck(),
+            new IllegalDataCheck(),
             new antiprefilledchests()
     ));
 

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
@@ -1,25 +1,75 @@
 package me.txmc.core.antiillegal.check.checks;
 
-import me.txmc.core.antiillegal.check.Check;import org.bukkit.inventory.ItemStack;
+import io.papermc.paper.datacomponent.item.DeathProtection;
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
- * @author 254n_m
- * @since 2023/09/29 6:53 PM
+ * @author MindComplexity
+ * @since 2025/09/17
  * This file was created as a part of 8b8tAntiIllegal
  */
+
 public class IllegalDataCheck implements Check {
+    private static final int MAX_LEGAL_AMPLIFIER = 5;
+    private static final int MAX_LEGAL_DURATION = 9600;
+
     @Override
     public boolean check(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return false;
+        
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        
+        try {
+            if (meta.isGlider() && item.getType() != Material.ELYTRA) {
+                return true;
+            }
+            
+            if (hasDeathProtectionComponent(meta) && item.getType() != Material.TOTEM_OF_UNDYING) {
+                return true;
+            }
+
+            if (hasIllegalFoodEffects(meta)) {
+                return true;
+            }
+            
+        } catch (Exception e) {
+            return false;
+        }
+        
         return false;
     }
 
     @Override
     public boolean shouldCheck(ItemStack item) {
-        return false;
+        return item != null && item.hasItemMeta();
     }
 
     @Override
     public void fix(ItemStack item) {
-
+        item.setAmount(0);
+    }
+    
+    private boolean hasDeathProtectionComponent(ItemMeta meta) {
+        String componentString = meta.getAsComponentString();
+        return componentString.contains("minecraft:death_protection");
+    }
+    
+    private boolean hasIllegalFoodEffects(ItemMeta meta) {
+        String componentString = meta.getAsComponentString().toLowerCase();
+        
+        if (componentString.contains("minecraft:food") || componentString.contains("minecraft:consumable")) {
+            if (componentString.contains("amplifier") && componentString.matches(".*amplifier[=\\s]+([6-9]|\\d{2,}).*")) {
+                return true;
+            }
+            
+            if (componentString.contains("duration") && componentString.matches(".*duration[=\\s]+(9[7-9][0-9]{2}|[1-9]\\d{5,}).*")) {
+                return true;
+            }
+        }        
+        return false;
     }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/IllegalDataCheck.java
@@ -11,8 +11,8 @@ import org.bukkit.inventory.meta.ItemMeta;
  * @since 2025/09/17
  * This file was created as a part of 8b8tAntiIllegal
  */
-
 public class IllegalDataCheck implements Check {
+    
     private static final int MAX_LEGAL_AMPLIFIER = 5;
     private static final int MAX_LEGAL_DURATION = 9600;
 
@@ -33,6 +33,10 @@ public class IllegalDataCheck implements Check {
             }
 
             if (hasIllegalFoodEffects(meta)) {
+                return true;
+            }
+            
+            if (hasIllegalBlockState(meta)) {
                 return true;
             }
             
@@ -71,5 +75,9 @@ public class IllegalDataCheck implements Check {
             }
         }        
         return false;
+    }
+    private boolean hasIllegalBlockState(ItemMeta meta) {
+        String componentString = meta.getAsComponentString();
+        return componentString.contains("waterlogged: \"true\"");
     }
 }

--- a/src/main/java/me/txmc/core/antiillegal/check/checks/PlayerEffectCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/PlayerEffectCheck.java
@@ -18,9 +18,7 @@ public class PlayerEffectCheck implements Check {
 
     // Vanilla potion effect limits: Map<EffectType, MaxLevel>
     private static final Map<PotionEffectType, Integer> VANILLA_LEVEL_LIMITS = new HashMap<>();
-    
     private static final int MAX_LEGAL_DURATION = 9600; // 8 minutes for vanilla potions
-    private static final int MAX_LEGAL_DURATION_EXTENDED = 10800; // 10 minutes (extended potions)
     private static final int MAX_LEGAL_DURATION_SPECIAL = 144000; // 120 minutes (edgecases like Bad Omen)
     
     static {
@@ -51,7 +49,6 @@ public class PlayerEffectCheck implements Check {
         // https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html
         // VANILLA_LEVEL_LIMITS.put(PotionEffectType.Fatal_Poison, 1);
         // Removed in 1.21
-        // VANILLA_LEVEL_LIMITS.put(PotionEffectType.RAID_OMEN, 0); // Pillager RAIDS
         // Illegal effects
         // VANILLA_LEVEL_LIMITS.put(PotionEffectType.HEALTH_BOOST, 0);
         // VANILLA_LEVEL_LIMITS.put(PotionEffectType.BAD_LUCK, 0);
@@ -87,6 +84,7 @@ public class PlayerEffectCheck implements Check {
         VANILLA_LEVEL_LIMITS.put(PotionEffectType.HUNGER, 3); // Pufferfish
         VANILLA_LEVEL_LIMITS.put(PotionEffectType.HERO_OF_THE_VILLAGE, 5); // Village curing
         VANILLA_LEVEL_LIMITS.put(PotionEffectType.BAD_OMEN, 5); // Pillager raids
+        VANILLA_LEVEL_LIMITS.put(PotionEffectType.RAID_OMEN, 5); // Pillager raids
     }
 
     @Override
@@ -172,12 +170,8 @@ public class PlayerEffectCheck implements Check {
     }
     
     private boolean isExcessiveDuration(int duration, PotionEffectType type) {
-        if (type == PotionEffectType.BAD_OMEN) {
+        if (type == PotionEffectType.BAD_OMEN || type == PotionEffectType.RAID_OMEN) {
             return duration > MAX_LEGAL_DURATION_SPECIAL;
-        }
-        
-        if (duration > MAX_LEGAL_DURATION_EXTENDED) {
-            return true;
         }
         return duration > MAX_LEGAL_DURATION;
     }

--- a/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/InventoryListeners.java
@@ -1,7 +1,11 @@
 package me.txmc.core.antiillegal.listeners;
 
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.BundleContents;
 import lombok.RequiredArgsConstructor;
 import me.txmc.core.antiillegal.AntiIllegalMain;
+import me.txmc.core.antiillegal.check.Check;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.*;
@@ -9,8 +13,8 @@ import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * @author 254n_m
- * @since 2023/10/15 4:30 AM
+ * @author 254n_m + MindComplexity
+ * @since 2023/10/15 4:30 AM, Updated 2025/09/17
  * This file was created as a part of 8b8tAntiIllegal
  */
 @RequiredArgsConstructor
@@ -30,26 +34,54 @@ public class InventoryListeners implements Listener {
     @EventHandler
     public void onClick(InventoryClickEvent event) {
         main.checkFixItem(event.getCursor(), event);
+        checkBundleContents(event.getCursor());
     }
 
     @EventHandler
     public void onHopper(InventoryMoveItemEvent event) {
         main.checkFixItem(event.getItem(), event);
+        checkBundleContents(event.getItem());
     }
 
     @EventHandler
     private void inventoryEvent(InventoryEvent event) {
-        for (ItemStack itemStack : event.getInventory()) main.checkFixItem(itemStack, null);
+        for (ItemStack itemStack : event.getInventory()) {
+            main.checkFixItem(itemStack, null);
+            checkBundleContents(itemStack);
+        }
     }
 
     @EventHandler
     private void inventoryClickEvent(InventoryClickEvent event) {
-        for (ItemStack itemStack : event.getInventory()) main.checkFixItem(itemStack, event);
+        for (ItemStack itemStack : event.getInventory()) {
+            main.checkFixItem(itemStack, event);
+            checkBundleContents(itemStack);
+        }
     }
 
     @EventHandler
     private void playerItemConsumeEvent(PlayerItemConsumeEvent event) {
-        for (ItemStack itemStack : event.getPlayer().getInventory()) main.checkFixItem(itemStack, event);
+        for (ItemStack itemStack : event.getPlayer().getInventory()) {
+            main.checkFixItem(itemStack, event);
+            checkBundleContents(itemStack);
+        }
     }
 
+    private void checkBundleContents(ItemStack item) {
+        if (item == null || item.getType() != Material.BUNDLE) return;
+        
+        BundleContents bundleContents = item.getData(DataComponentTypes.BUNDLE_CONTENTS);
+        if (bundleContents == null) return;
+        
+        for (ItemStack bundleItem : bundleContents.contents()) {
+            if (bundleItem == null) continue;
+            
+            for (Check check : main.checks()) {
+                if (check.shouldCheck(bundleItem) && check.check(bundleItem)) {
+                    item.setAmount(0);
+                    return;
+                }
+            }
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-#8b8tCore Version 1.6.2
+#8b8tCore Version 1.6.3
 AntiIllegal:
   Enabled: true
   EnableIllegalBlocksCleaner: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: 8b8tCore
 main: me.txmc.core.Main
-version: 1.6.2
+version: 1.6.3
 author: 254n_m, agarciacort, Leeewith3Es, MindComplexity
 description: A core plugin for 8b8t
 api-version: 1.21


### PR DESCRIPTION
# Changelogs
Illegal Data Check:

This checks NBT data for illegal items such as:

* Illegal food allowing bypass of the player effect check by spamming it really fast.
* Mangrove Roots allowing water in the Nether via the Waterlogged tag. This has been fixed.
* Illegal Totem Items (ex: Stone Block acting as a totem)
* Illegal Gliders (ex: Stone Block acting as an elytra)

Bundles Check

This check will now run all checks for all bundles and delete illegal items. Bundles are commonly used to bypass checks entirely. This has been patched.

Bug Fixes:

Fixed Raid Omen being falsely flagged by the system.