### PR TITLE
Bug Fixes for 1.9.0

### DIFF
--- a/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
+++ b/src/main/java/me/txmc/core/antiillegal/check/checks/NameCheck.java
@@ -26,10 +26,7 @@ public class NameCheck implements Check {
 
     private final ConfigurationSection config;
 
-    private static final Pattern ILLEGAL_CHAR_PATTERN =
-            Pattern.compile("[^\\u0020-\\u007E]");
-
-    private static final int STRICT_MAX_LENGTH = 128;
+    private static final int STRICT_MAX_LENGTH = 255;
     private static final int MAX_JSON_LENGTH = 8192;
 
     private static final DataComponentType ENTITY_DATA =
@@ -82,9 +79,12 @@ public class NameCheck implements Check {
         if (json.length() > MAX_JSON_LENGTH) return true;
 
         String content = GlobalUtils.getStringContent(component);
-
         if (content.length() > STRICT_MAX_LENGTH) return true;
-        return ILLEGAL_CHAR_PATTERN.matcher(content).find();
+        
+        return content.codePoints().anyMatch(cp -> 
+                Character.isISOControl(cp) || 
+                Character.getType(cp) == Character.PRIVATE_USE
+        );
     }
 
     private boolean hasIllegalEntityData(ItemStack item) {

--- a/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
+++ b/src/main/java/me/txmc/core/antiillegal/listeners/IllegalBlocksCleaner.java
@@ -72,7 +72,10 @@ public class IllegalBlocksCleaner implements Listener {
 
     private void scanChunk(Chunk chunk, World world, int cx, int cz, long chunkKey) {
         if (Math.abs(cx) >= 1875000 || Math.abs(cz) >= 1875000) return;
-        
+                
+        /*
+        // Cache Disabled here: This approach is not reliable enough due to players constantly unloading chunks.
+        // Server Check up task completely ignores the constant unloading of chunks.s
         if (enableSessionCache && sessionCache.contains(chunkKey)) return;
 
         PersistentDataContainer pdc = chunk.getPersistentDataContainer();
@@ -83,6 +86,7 @@ public class IllegalBlocksCleaner implements Listener {
                 return;
             }
         }
+        */
 
         World.Environment env = world.getEnvironment();
         int minY = world.getMinHeight();
@@ -127,7 +131,6 @@ public class IllegalBlocksCleaner implements Listener {
                     if (!world.isChunkLoaded(cx, cz)) return;
 
                     if (toRemove.isEmpty()) {
-                        markChunkAsClean(world, cx, cz, chunkKey);
                         return;
                     }
 
@@ -204,8 +207,6 @@ public class IllegalBlocksCleaner implements Listener {
                 if (!world.isChunkLoaded(cx, cz)) return;
                 processBlockRemoval(world, cx, cz, chunkKey, anchorLoc, queue);
             }, delayTicks);
-        } else {
-            markChunkAsClean(world, cx, cz, chunkKey);
         }
     }
 

--- a/src/main/java/me/txmc/core/patch/listeners/MapCreationListener.java
+++ b/src/main/java/me/txmc/core/patch/listeners/MapCreationListener.java
@@ -8,14 +8,18 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.MapInitializeEvent;
+import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.MapMeta;
@@ -31,7 +35,8 @@ import java.util.stream.Collectors;
  * This file is apart of the 8b8tCore plugin.
  * @author MindComplexity (aka Libalpm)
  * @since 2026/01/08
- */
+*/
+
 @Slf4j
 @RequiredArgsConstructor
 public class MapCreationListener implements Listener {
@@ -41,59 +46,89 @@ public class MapCreationListener implements Listener {
 
     @EventHandler
     public void onMapInitialize(MapInitializeEvent event) {
-        MapView mapView = event.getMap();
-        World world = mapView.getWorld();
-        
-        if (world == null) return;
-
-        int x = mapView.getCenterX();
-        int z = mapView.getCenterZ();
-        int chunkX = x >> 4;
-        int chunkZ = z >> 4;
-
-        if (!world.isChunkLoaded(chunkX, chunkZ)) {
-            return;
+        MapView map = event.getMap();
+        if (map != null) {
+            map.setTrackingPosition(false);
+            map.setUnlimitedTracking(false);
         }
+    }
 
-        Location center = new Location(world, x, 64, z);
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMapCreateAttempt(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_AIR && 
+            event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.MAP) return;
 
-        Bukkit.getRegionScheduler().run(plugin, center, task -> {
-            if (!world.isChunkLoaded(chunkX, chunkZ)) return;
-
-            java.util.Collection<Player> nearbyPlayers = world.getNearbyPlayers(center, SCAN_RADIUS);
+        Player player = event.getPlayer();
+        
+        player.getScheduler().run(plugin, task -> {
+            if (!player.isOnline()) return;
             
-            if (nearbyPlayers.isEmpty()) return;
-
-            String playerNames = nearbyPlayers.stream()
+            String playerNames = player.getWorld().getNearbyPlayers(player.getLocation(), SCAN_RADIUS)
+                    .stream()
                     .map(Player::getName)
                     .collect(Collectors.joining(", @"));
 
-            for (Player player : nearbyPlayers) {
-                signPlayerMap(player, mapView.getId(), playerNames);
+            ItemStack main = player.getInventory().getItemInMainHand();
+            if (main.getType() == Material.FILLED_MAP) {
+                if (main.getItemMeta() instanceof MapMeta mm && mm.hasMapId()) {
+                    signPlayerMap(player, mm.getMapId(), playerNames);
+                }
             }
-        });
+
+            ItemStack off = player.getInventory().getItemInOffHand();
+            if (off.getType() == Material.FILLED_MAP) {
+                if (off.getItemMeta() instanceof MapMeta mm && mm.hasMapId()) {
+                    signPlayerMap(player, mm.getMapId(), playerNames);
+                }
+            }
+        }, null);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onChunkLoad(ChunkLoadEvent event) {
+        for (Entity entity : event.getChunk().getEntities()) {
+            if (entity instanceof ItemFrame frame) {
+                ItemStack frameItem = frame.getItem();
+                if (frameItem.getType() == Material.FILLED_MAP) {
+                    sanitizeFrameMap(frame, frameItem);
+                }
+            }
+        }
+    }
+
+    private void sanitizeFrameMap(ItemFrame frame, ItemStack item) {
+        if (!(item.getItemMeta() instanceof MapMeta mm)) return;
+        if (!mm.hasMapId()) return;
+        
+        MapView view = Bukkit.getMap(mm.getMapId());
+        if (view != null) {
+            view.setTrackingPosition(false);
+            view.setUnlimitedTracking(false);
+        }
     }
 
     private void signPlayerMap(Player player, int mapId, String signatureText) {
         ItemStack mainHand = player.getInventory().getItemInMainHand();
-        if (signIfMatches(mainHand, mapId, signatureText, player)) return;
+        if (signIfMatches(mainHand, mapId, signatureText)) return;
 
         ItemStack offHand = player.getInventory().getItemInOffHand();
-        if (signIfMatches(offHand, mapId, signatureText, player)) return;
+        if (signIfMatches(offHand, mapId, signatureText)) return;
 
         for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null) {
-                signIfMatches(item, mapId, signatureText, player);
+            if (item != null && signIfMatches(item, mapId, signatureText)) {
+                break;
             }
         }
     }
 
-    private boolean signIfMatches(ItemStack item, int mapId, String signatureText, Player player) {
+    private boolean signIfMatches(ItemStack item, int mapId, String signatureText) {
         if (item == null || item.getType() != Material.FILLED_MAP) return false;
 
         ItemMeta meta = item.getItemMeta();
         if (!(meta instanceof MapMeta mapMeta)) return false;
-
         if (!mapMeta.hasMapId() || mapMeta.getMapId() != mapId) return false;
 
         NamespacedKey key = new NamespacedKey(plugin, "map_id");
@@ -102,9 +137,6 @@ public class MapCreationListener implements Listener {
         }
 
         applySignature(item, meta, signatureText, mapId);
-        
-        log.debug("Signed map {} for {}", mapId, player.getName());
-        
         return true;
     }
 
@@ -123,12 +155,10 @@ public class MapCreationListener implements Listener {
         }
         
         meta.lore(lore);
-
-        NamespacedKey keyAuthor = new NamespacedKey(plugin, "map_author");
-        meta.getPersistentDataContainer().set(keyAuthor, PersistentDataType.STRING, players);
-        
-        NamespacedKey keyId = new NamespacedKey(plugin, "map_id");
-        meta.getPersistentDataContainer().set(keyId, PersistentDataType.INTEGER, mapId);
+        meta.getPersistentDataContainer().set(
+            new NamespacedKey(plugin, "map_author"), PersistentDataType.STRING, players);
+        meta.getPersistentDataContainer().set(
+            new NamespacedKey(plugin, "map_id"), PersistentDataType.INTEGER, mapId);
 
         item.setItemMeta(meta);
     }

--- a/src/main/java/me/txmc/core/patch/listeners/MapRemovalPatch.java
+++ b/src/main/java/me/txmc/core/patch/listeners/MapRemovalPatch.java
@@ -57,7 +57,7 @@ public class MapRemovalPatch implements Listener {
         if (event.getWhoClicked() instanceof Player player) {
             removeRestrictedMaps(event.getInventory(), player);
             if (isRestrictedMap(event.getCursor())) {
-                event.setCursor(null);
+                event.getView().setCursor(null);
                 sendPrefixedLocalizedMessage(player, "mapart_deleted_inventory");
             }
         }

--- a/src/main/java/me/txmc/core/util/GlobalUtils.java
+++ b/src/main/java/me/txmc/core/util/GlobalUtils.java
@@ -349,8 +349,10 @@ public class GlobalUtils {
         }
 
         if (component instanceof net.kyori.adventure.text.TranslatableComponent translatable) {
-            for (Component arg : translatable.args()) {
-                maxDepth = Math.max(maxDepth, getComponentDepth(arg, currentDepth + 1, visited));
+            for (net.kyori.adventure.text.TranslationArgument arg : translatable.arguments()) {
+                if (arg instanceof Component) {
+                    maxDepth = Math.max(maxDepth, getComponentDepth((Component) arg, currentDepth + 1, visited));
+                }
                 if (maxDepth > 50) return maxDepth;
             }
         }


### PR DESCRIPTION
- Fixed entity and item names reverting due to an overly strict check.
- Fixed map authors not displaying correctly.
- Fixed map tracking banners and entities causing severe lag or client crashes.
- Disabled the compass tracking feature on all server maps to prevent players from being tracked up to 50,000 blocks away.
- Removed the PDC approach (it's really stupid).