### PR TITLE
Modified tablist and cosmetics to be on entity scheduler and not on async threads.

### DIFF
--- a/src/main/java/me/txmc/core/chat/ChatSection.java
+++ b/src/main/java/me/txmc/core/chat/ChatSection.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 
@@ -92,28 +93,34 @@ public class ChatSection implements Section {
         loadAllDataAsync(info);
     }
 
-    public void loadAllDataAsync(ChatInfo info) {
+    /**
+     * Loads all chat/cosmetics data asynchronously. Returns a CompletableFuture that completes
+     * when all data (including prefix/title from refreshPrefixDataAsync) is loaded.
+     * Required for Folia: callers can chain tab updates to run after this completes.
+     */
+    public CompletableFuture<Void> loadAllDataAsync(ChatInfo info) {
         String username = info.getPlayer().getName();
         GeneralDatabase db = GeneralDatabase.getInstance();
         me.txmc.core.customexperience.util.PrefixManager pm = new me.txmc.core.customexperience.util.PrefixManager();
 
-        db.loadPlayerDataCache(username).thenAccept(pd -> {
-            info.setMutedUntil(pd.getLong("muted", 0L));
-            info.setNickname(pd.getString("displayname"));
-            info.setUseVanillaLeaderboard(pd.getBoolean("useVanillaLeaderboard", false));
-            info.setNameGradient(pd.getString("customGradient"));
-            info.setNameAnimation(pd.getString("gradient_animation"));
-            info.setNameSpeed(pd.getInt("gradient_speed", 5));
-            info.setNameDecorations(pd.getString("nameDecorations"));
-            info.setHideAnnouncements(pd.getBoolean("hideAnnouncements", false));
-            info.setHidePrefix(pd.getBoolean("hidePrefix", false));
-            
-            pm.refreshPrefixDataAsync(info);
-            info.setDataLoaded(true);
-        }).exceptionally(e -> {
-            e.printStackTrace();
-            return null;
-        });
+        return db.loadPlayerDataCache(username)
+                .thenAccept(pd -> {
+                    info.setMutedUntil(pd.getLong("muted", 0L));
+                    info.setNickname(pd.getString("displayname"));
+                    info.setUseVanillaLeaderboard(pd.getBoolean("useVanillaLeaderboard", false));
+                    info.setNameGradient(pd.getString("customGradient"));
+                    info.setNameAnimation(pd.getString("gradient_animation"));
+                    info.setNameSpeed(pd.getInt("gradient_speed", 5));
+                    info.setNameDecorations(pd.getString("nameDecorations"));
+                    info.setHideAnnouncements(pd.getBoolean("hideAnnouncements", false));
+                    info.setHidePrefix(pd.getBoolean("hidePrefix", false));
+                })
+                .thenCompose(v -> pm.refreshPrefixDataAsync(info))
+                .thenRun(() -> info.setDataLoaded(true))
+                .exceptionally(e -> {
+                    e.printStackTrace();
+                    return null;
+                });
     }
 
     public void removePlayer(Player player) {

--- a/src/main/java/me/txmc/core/command/commands/CosmeticsCommand.java
+++ b/src/main/java/me/txmc/core/command/commands/CosmeticsCommand.java
@@ -357,7 +357,7 @@ public class CosmeticsCommand extends BaseTabCommand {
             for (int i = 3; i < args.length; i++) {
                 String arg = args[i].toLowerCase();
                 if (!arg.matches("^\\d+:[a-z/]+:#[0-9a-f]{6}$")) {
-                    sendMessage(player, "&cInvalid part format: " + arg + ". Expected length:decorations:#color");
+                    player.getScheduler().run(Main.getInstance(), (t) -> sendMessage(player, "&cInvalid part format: " + arg + ". Expected length:decorations:#color"), null);
                     return;
                 }
                 String[] split = arg.split(":");
@@ -366,13 +366,13 @@ public class CosmeticsCommand extends BaseTabCommand {
                     totalLength += len;
                     parts.add(arg);
                 } catch (NumberFormatException e) {
-                    sendMessage(player, "&cInvalid length in part: " + arg);
+                    player.getScheduler().run(Main.getInstance(), (t) -> sendMessage(player, "&cInvalid length in part: " + arg), null);
                     return;
                 }
             }
 
             if (totalLength != nickLength) {
-                sendMessage(player, "&cTotal length of parts (" + totalLength + ") does not match nickname length (" + nickLength + ")");
+                player.getScheduler().run(Main.getInstance(), (t) -> sendMessage(player, "&cTotal length of parts (" + totalLength + ") does not match nickname length (" + nickLength + ")"), null);
                 return;
             }
 
@@ -380,7 +380,7 @@ public class CosmeticsCommand extends BaseTabCommand {
             database.updateCustomGradient(player.getName(), tobiasFormat).thenRun(() -> {
                 GlobalUtils.updateDisplayNameAsync(player).thenRun(() -> refreshPlayer(player));
             });
-            sendMessage(player, "&aNickname set to special Tobias format!");
+            player.getScheduler().run(Main.getInstance(), (t) -> sendMessage(player, "&aNickname set to special Tobias format!"), null);
         });
     }
 
@@ -405,7 +405,7 @@ public class CosmeticsCommand extends BaseTabCommand {
 
         database.insertNickname(player.getName(), plain).thenRun(() -> {
             GlobalUtils.updateDisplayNameAsync(player).thenRun(() -> refreshPlayer(player));
-            sendPrefixedLocalizedMessage(player, "nick_success", plain);
+            player.getScheduler().run(Main.getInstance(), (t) -> sendPrefixedLocalizedMessage(player, "nick_success", plain), null);
         });
     }
 
@@ -513,10 +513,20 @@ public class CosmeticsCommand extends BaseTabCommand {
             me.txmc.core.chat.ChatInfo info = chatSec.getInfo(player);
             if (info != null) {
                 info.clearAnimatedNameCache();
-                chatSec.loadAllDataAsync(info);
+                // Wait for async data load to complete before updating tab - fixes Folia race where
+                // tab update could run before Cosmetics data was loaded
+                chatSec.loadAllDataAsync(info).thenRun(() -> {
+                    player.getScheduler().runDelayed(plugin, (task) -> {
+                        if (!player.isOnline()) return;
+                        me.txmc.core.Section section = plugin.getSectionByName("TabList");
+                        if (section instanceof me.txmc.core.tablist.TabSection tabSection) {
+                            tabSection.setTab(player, true);
+                        }
+                    }, null, 1L);
+                });
+                return;
             }
         }
-        
         player.getScheduler().runDelayed(plugin, (task) -> {
             if (!player.isOnline()) return;
             me.txmc.core.Section section = plugin.getSectionByName("TabList");

--- a/src/main/java/me/txmc/core/tablist/TabSection.java
+++ b/src/main/java/me/txmc/core/tablist/TabSection.java
@@ -53,9 +53,13 @@ public class TabSection implements Section {
                 boolean updatePlaceholders = (tickCount % 10 == 0); 
                 long animTick = me.txmc.core.util.GradientAnimator.getAnimationTick();
                 
-                java.util.Map<String, Component> prefixCache = new java.util.HashMap<>();
                 for (Player p : Bukkit.getOnlinePlayers()) {
-                    setTab(p, updatePlaceholders, animTick, prefixCache);
+                    final Player player = p;
+                    // Run setTab on each player's entity scheduler - required for Folia
+                    player.getScheduler().run(plugin, (t) -> {
+                        java.util.Map<String, Component> prefixCache = new java.util.HashMap<>();
+                        setTab(player, updatePlaceholders, animTick, prefixCache);
+                    }, null);
                 }
             } catch (Throwable t) {
                 plugin.getLogger().warning("Error in TabList update task: " + t.getMessage());
@@ -111,10 +115,15 @@ public class TabSection implements Section {
 
         if (updatePlaceholders) {
             Localization loc = Localization.getLocalization(player.locale().getLanguage());
+            // Schedule header/footer on player's entity scheduler - CompletableFuture callbacks run on async threads
             Utils.parsePlaceHolders(String.join("\n", loc.getStringList("TabList.Header")), player, plugin.getStartTime())
-                    .thenAccept(player::sendPlayerListHeader);
+                    .thenAccept(component -> player.getScheduler().run(plugin, t -> {
+                        if (player.isOnline()) player.sendPlayerListHeader(component);
+                    }, null));
             Utils.parsePlaceHolders(String.join("\n", loc.getStringList("TabList.Footer")), player, plugin.getStartTime())
-                    .thenAccept(player::sendPlayerListFooter);
+                    .thenAccept(component -> player.getScheduler().run(plugin, t -> {
+                        if (player.isOnline()) player.sendPlayerListFooter(component);
+                    }, null));
         }
     }
 


### PR DESCRIPTION
All player related operations should be ran on each player’s entity scheduler, not on global or async threads.